### PR TITLE
refactor: Desktop viewport error handling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "davidanson.vscode-markdownlint"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-    "recommendations": [
-      "davidanson.vscode-markdownlint",
-      "editorconfig.editorconfig"
-    ]
-}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "davidanson.vscode-markdownlint"
+      "davidanson.vscode-markdownlint",
+      "editorconfig.editorconfig"
     ]
 }


### PR DESCRIPTION
## summary of changes

- broke out custom css into styles.css
- added error handling for viewport sizes
- TODO: fix full viewport caption on basic terms (http://127.0.0.1:5500/docs/index.html#/8/0/1)

## how to test

- checkout branch

```bash
git fetch origin
git checkout __
```

- verify styling looks the same with more flexibility on desktop with high resolution monitors (e.g., captions aren't cutoff in full viewport aside from basic terms slide)
- See slides:
  - 4 
  - 5
  - 6
  - 7
  - 8
  - 9

### Exhibit A

![exhibit_a](https://github.com/user-attachments/assets/33c764e7-a707-4494-8017-72fe0cf7d89b)


### Exhibit B

![exhibit_b](https://github.com/user-attachments/assets/00bf4223-9174-4735-8610-5a21f03a2dd6)
